### PR TITLE
Read codemeta

### DIFF
--- a/extract/extract.py
+++ b/extract/extract.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python
+
+import urllib.request
+import json
+import os, tempfile
+from pathlib import Path
+import filecmp
+from jsonschema import validate
+
+if not os.path.exists("softwares"):
+    os.makedirs("softwares")
+
+# the list of fields to extract from the codemeta.json
+fields = ['description', 'name', 'documentation', 'packages']
+
+with open("software.txt", "r") as swfile:
+    for line in swfile:
+        xline = line.strip()
+        # Get the codemeta.json for the software
+        urllib.request.urlretrieve(xline, "codemeta.json")
+
+        # generate the json description
+        with open("codemeta.json", "r") as jsonfile:
+            data = json.load(jsonfile)
+            swname = data['name']
+            fd, path = tempfile.mkstemp()
+            with os.fdopen(fd, 'w') as tmp:
+                tmp.write("\t{\n")
+                for f in fields:
+                    tmp.write("\t\t\"{}\": \"{}\",\n".format(f, data[f]))
+                tmp.write("\t}\n")
+
+        # compare to the existing one
+        swpath = "softwares/" + swname + ".json"
+        if (Path(swpath).exists()):
+            print("Description for software '{}' exists.".format(swname))
+            if filecmp.cmp(swpath, path):
+                print("And it has not changed. No need to update it.")
+                os.unlink(path)
+            else:
+                print("And it has changed. Needs to be updated".format(swname))
+                os.rename(path, swpath)
+        else:
+            print("Description for software '{}' DOES NOT exist. Create it.".format(swname))
+            os.rename(path, swpath)
+
+        # delete codemeta json file
+        os.unlink("codemeta.json")
+

--- a/extract/software.txt
+++ b/extract/software.txt
@@ -1,0 +1,1 @@
+https://gitlab.inria.fr/furmento/numpex/-/raw/main/codemeta.json

--- a/main-list/projects.json
+++ b/main-list/projects.json
@@ -61,7 +61,7 @@
       "documentation": "https://starpu.gitlabpages.inria.fr/doc.html",
       "guix_package": "https://gitlab.inria.fr/guix-hpc/guix-hpc/-/blob/master/inria/storm.scm",
       "name": "StarPU",
-      "spack_package": "https://github.com/spack/spack-packages/tree/develop/repos/spack_repo/builtin/packages/starpug/package.py"
+      "spack_package": "https://github.com/spack/spack-packages/tree/develop/repos/spack_repo/builtin/packages/starpu/package.py"
     },
     {
       "description": "Composyx is a linear algebra modern C++ library focused on composability. Its purpose is to allow the user to express a large panel of numerical algorithms using a high-level interface to range from laptop prototypes to many node supercomputer parallel computations.",

--- a/main-list/projects.json
+++ b/main-list/projects.json
@@ -57,11 +57,11 @@
     },
     {
       "description": "StarPU is a task-based runtime system for heterogeneous platforms coupling a performance modeling scheduler with a distributed shared-memory manager. It provides a framework for task scheduling on heterogeneous, accelerated platforms, together with an API for implementing various classes of scheduling algorithms. This scheduling framework jointly works with a distributed shared-memory manager to optimize task mappings and data transfers, and to overlap communications with computations.",
-      "discussion": "https://gitlab.inria.fr/starpu/starpu/-/issues",
-      "documentation": "https://starpu.gitlabpages.inria.fr/",
+      "discussion": "https://discord.gg/vKVJsuHB8U",
+      "documentation": "https://starpu.gitlabpages.inria.fr/doc.html",
       "guix_package": "https://gitlab.inria.fr/guix-hpc/guix-hpc/-/blob/master/inria/storm.scm",
       "name": "StarPU",
-      "spack_package": "https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/starpu/package.py"
+      "spack_package": "https://github.com/spack/spack-packages/tree/develop/repos/spack_repo/builtin/packages/starpug/package.py"
     },
     {
       "description": "Composyx is a linear algebra modern C++ library focused on composability. Its purpose is to allow the user to express a large panel of numerical algorithms using a high-level interface to range from laptop prototypes to many node supercomputer parallel computations.",


### PR DESCRIPTION
new mechanisms to automatically read codemeta.json
    
    Instead of updating the main-list/projects.json, one only needs to
    provide the URL of the codemeta.json file for their softwares.
    
    It will be automatically read and will update the main-list/projects.json
    if needed.
    
    This code does not respect the grammar of main-list/projects.json as
    it defines the spack and guix packages in a unique package field.
    
    This does not completely work yet, as the main-list/projects.json
    needs the fields documentation and packages which are not yet present
    in the codemeta grammar as defined in https://doi.org/10.5063/schema/codemeta-2.0
    
    We would either need to extend the grammar or define a specific numpex
    grammar.
    
    Hence the example for StarPU is using a codemeta.json file which is
    not valid as it defines the documentation and package fields.
