### PR TITLE
Add StarPU codemeta in mapping file

### DIFF
--- a/main-list/mapping.json
+++ b/main-list/mapping.json
@@ -8,8 +8,8 @@
                 "description": ".description",
                 "discussion": ".softwareSuggestions",
                 "documentation": ".softwareHelp",
-		        "guix_package": ".packages[] | select(.name == \"guix\") | .url",
-		        "spack_package": ".packages[] | select(.name == \"spack\") | .url"
+		        "guix_package": ".installURL[] | select(.name == \"guix\") | .url",
+		        "spack_package": ".installURL[] | select(.name == \"spack\") | .url"
             }
         }      
     ]  


### PR DESCRIPTION
See #18 for the context.

Based on the following "extension" of Codemeta in StarPU:

~~~~json
    "softwareHelp": "https://starpu.gitlabpages.inria.fr/doc.html",
    "installURL" : [
        {
            "name" : "guix",
            "url" : "https://gitlab.inria.fr/guix-hpc/guix-hpc/-/blob/master/inria/storm.scm"
        },
        {
            "name" : "spack",
            "url" : "https://github.com/spack/spack-packages/tree/develop/repos/spack_repo/builtin/packages/starpu/package.py"
        }
    ],
    "softwareSuggestions" : "https://discord.gg/vKVJsuHB8U"
~~~~